### PR TITLE
Drop Scala 2.12, use pooled implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,11 +29,9 @@ val Versions = new {
 
   val Scala213 = "2.13.8"
 
-  val Scala212 = "2.12.16"
-
   val Scala3 = "3.2.0"
 
-  val allScala = Seq(Scala3, Scala212, Scala213)
+  val allScala = Seq(Scala3, Scala213)
 
   val Weaver = "0.8.0"
 
@@ -44,6 +42,8 @@ val Versions = new {
   val Playwright = "1.26.0"
 
   val OrganizeImports = "0.6.0"
+
+  val PoolParty = "0.0.3"
 
 }
 
@@ -70,6 +70,7 @@ lazy val core = projectMatrix
       "org.typelevel"           %% "cats-effect"        % Versions.CatsEffect,
       "org.typelevel"           %% "cats-effect-kernel" % Versions.CatsEffect,
       "org.typelevel"           %% "cats-effect-std"    % Versions.CatsEffect,
+      "org.tpolecat"            %% "pool-party"         % Versions.PoolParty,
       "com.microsoft.playwright" % "playwright"         % Versions.Playwright
     ),
     testFrameworks += new TestFramework("weaver.framework.CatsEffect")

--- a/modules/weaver/src/test/scala/ExampleTests.scala
+++ b/modules/weaver/src/test/scala/ExampleTests.scala
@@ -10,7 +10,9 @@ import weaver.GlobalWrite
 
 object SharedResources extends weaver.GlobalResource {
   override def sharedResources(global: GlobalWrite): Resource[IO, Unit] =
-    PlaywrightRuntime.create().flatMap(global.putR(_)).void
+    PlaywrightRuntime
+      .create(poolSize = 8)
+      .flatMap(global.putR(_))
 }
 
 class BasicTests(global: weaver.GlobalRead)
@@ -23,26 +25,28 @@ class BasicTests(global: weaver.GlobalRead)
   val filepath = Paths.get("test.html").toAbsolutePath()
   val uri      = "file://" + filepath.toString
 
-  pageTest("check title") { pc =>
-    for {
-      _     <- pc.page(_.navigate(uri))
-      title <- pc.page(_.title())
-    } yield expect(title == "Weaver Playwright")
-  }
+  (0 to 5).foreach { i =>
+    pageTest(s"check title $i") { pc =>
+      for {
+        _     <- pc.page(_.navigate(uri))
+        title <- pc.page(_.title())
+      } yield expect(title == "Weaver Playwright")
+    }
 
-  pageTest("click button") { pc =>
-    val invalidCredentials =
-      pc.locator("text=Invalid credentials").map(_.count())
+    pageTest(s"click button $i") { pc =>
+      val invalidCredentials =
+        pc.locator("text=Invalid credentials").map(_.count())
 
-    for {
-      _ <- pc.page(_.navigate(uri))
-      _ <- eventually(invalidCredentials)(ic => expect(ic == 0))
-      _ <- pc.locator("text=submit").map(_.first().click())
-      _ <-
-        eventually(invalidCredentials)(ic => expect(ic == 1))
-          .onError(_ =>
-            pc.screenshot(Paths.get("failed-to-see-invalid-credentials.png"))
-          )
-    } yield success
+      for {
+        _ <- pc.page(_.navigate(uri))
+        _ <- eventually(invalidCredentials)(ic => expect(ic == 0))
+        _ <- pc.locator("text=submit").map(_.first().click())
+        _ <-
+          eventually(invalidCredentials)(ic => expect(ic == 1))
+            .onError(_ =>
+              pc.screenshot(Paths.get("failed-to-see-invalid-credentials.png"))
+            )
+      } yield success
+    }
   }
 }


### PR DESCRIPTION
This allows running tests with some level of parallelism, which is especially useful when they're failing, and you start getting stacked timeouts..